### PR TITLE
Rework of time and date formatting

### DIFF
--- a/phoneApp/src/main/java/com/corvettecole/pixelwatchface/MainActivity.java
+++ b/phoneApp/src/main/java/com/corvettecole/pixelwatchface/MainActivity.java
@@ -9,7 +9,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.text.format.DateFormat;
 import android.util.Log;
 import android.view.View;
 import android.widget.CompoundButton;
@@ -56,12 +55,10 @@ public class MainActivity extends AppCompatActivity implements
     AcknowledgePurchaseResponseListener {
 
   private SharedPreferences sharedPreferences;
-  private Switch use24HourTimeSwitch;
   private Switch showTemperatureSwitch;
   private Switch useCelsiusSwitch;
   private Switch showWeatherSwitch;
 
-  private Switch useEuropeanDateFormatSwitch;
   private Switch showTemperatureDecimalSwitch;
   private Switch useThinAmbientSwitch;
   private Switch showInfoBarAmbientSwitch;
@@ -77,11 +74,9 @@ public class MainActivity extends AppCompatActivity implements
   private MaterialButton advancedFreebieButton;
   private ProgressBar advancedProgressBar;
 
-  private boolean use24HourTime;
   private boolean showTemperature;
   private boolean useCelsius;
   private boolean showWeather;
-  private boolean useEuropeanDateFormat;
   private boolean showTemperatureDecimalPoint;
   private String darkSkyAPIKey;
   private boolean useDarkSky;
@@ -105,12 +100,10 @@ public class MainActivity extends AppCompatActivity implements
     sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
     //Wearable.getDataClient(getApplicationContext()).addListener(this);
 
-    use24HourTimeSwitch = findViewById(R.id.timeFormatSwitch);
     showTemperatureSwitch = findViewById(R.id.temperatureSwitch);
     useCelsiusSwitch = findViewById(R.id.celsiusSwitch);
     showWeatherSwitch = findViewById(R.id.weatherSwitch);
 
-    useEuropeanDateFormatSwitch = findViewById(R.id.dateFormatSwitch);
     showTemperatureDecimalSwitch = findViewById(R.id.temperaturePrecisionSwitch);
     useThinAmbientSwitch = findViewById(R.id.useThinAmbientSwitch);
     showInfoBarAmbientSwitch = findViewById(R.id.infoBarAmbientSwitch);
@@ -143,14 +136,6 @@ public class MainActivity extends AppCompatActivity implements
 //                findViewById(R.id.filled_exposed_dropdown);
 //        editTextFilledExposedDropdown.setAdapter(adapter);
 
-    use24HourTimeSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-      @Override
-      public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        sharedPreferences.edit().putBoolean("use_24_hour_time", isChecked).apply();
-        syncToWear();
-      }
-    });
-
     showTemperatureSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -182,15 +167,6 @@ public class MainActivity extends AppCompatActivity implements
         }
       }
     });
-
-    useEuropeanDateFormatSwitch
-        .setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-          @Override
-          public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-            sharedPreferences.edit().putBoolean("use_european_date", isChecked).apply();
-            syncToWear();
-          }
-        });
 
     showTemperatureDecimalSwitch
         .setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -319,30 +295,24 @@ public class MainActivity extends AppCompatActivity implements
   }
 
   private void setSuggestedSettings() {
-    use24HourTime = DateFormat.is24HourFormat(getApplicationContext());
     boolean metric = UnitLocale.getDefault() == UnitLocale.Metric;
     useCelsius = metric;
-    useEuropeanDateFormat = metric;
     SharedPreferences.Editor editor = sharedPreferences.edit();
-    editor.putBoolean("use_24_hour_time", use24HourTime);
-    editor.putBoolean("use_celsius", useCelsius);
-    editor.putBoolean("use_european_date", useEuropeanDateFormat).apply();
+    editor.putBoolean("use_celsius", useCelsius).apply();
     syncToWear();
   }
 
   private boolean shouldSuggestSettings() {
     // if any of the settings are not their initial default values, or this isn't the first time the app was launched
-    return showBattery && !use24HourTime && !showTemperature && useCelsius && !showWeather &&
-        !useEuropeanDateFormat && !showTemperatureDecimalPoint && !useThinAmbient &&
+    return showBattery && !showTemperature && useCelsius && !showWeather &&
+        !showTemperatureDecimalPoint && !useThinAmbient &&
         showInfoBarAmbient && !showWearIcon && !advanced && firstLaunch;
   }
 
   private void loadPreferences() {
-    use24HourTime = sharedPreferences.getBoolean("use_24_hour_time", false);
     showTemperature = sharedPreferences.getBoolean("show_temperature", false);
     useCelsius = sharedPreferences.getBoolean("use_celsius", true);
     showWeather = sharedPreferences.getBoolean("show_weather", false);
-    useEuropeanDateFormat = sharedPreferences.getBoolean("use_european_date", false);
     showTemperatureDecimalPoint = sharedPreferences.getBoolean("show_temperature_decimal", false);
     useThinAmbient = sharedPreferences.getBoolean("use_thin_ambient", false);
     showInfoBarAmbient = sharedPreferences.getBoolean("show_infobar_ambient", true);
@@ -367,18 +337,15 @@ public class MainActivity extends AppCompatActivity implements
     PutDataMapRequest putDataMapReq = PutDataMapRequest.create("/settings");
 
         /* Reference DataMap retrieval code on the WearOS app
-                mUse24HourTime = dataMap.getBoolean("use_24_hour_time");
                 mShowTemperature = dataMap.getBoolean("show_temperature");
                 mUseCelsius = dataMap.getBoolean("use_celsius");
                 mShowWeather = dataMap.getBoolean("show_weather");
                 */
 
     putDataMapReq.getDataMap().putLong("timestamp", System.currentTimeMillis());
-    putDataMapReq.getDataMap().putBoolean("use_24_hour_time", use24HourTime);
     putDataMapReq.getDataMap().putBoolean("show_temperature", showTemperature);
     putDataMapReq.getDataMap().putBoolean("use_celsius", useCelsius);
     putDataMapReq.getDataMap().putBoolean("show_weather", showWeather);
-    putDataMapReq.getDataMap().putBoolean("use_european_date", useEuropeanDateFormat);
     putDataMapReq.getDataMap().putBoolean("show_temperature_decimal", showTemperatureDecimalPoint);
     putDataMapReq.getDataMap().putBoolean("use_thin_ambient", useThinAmbient);
     putDataMapReq.getDataMap().putBoolean("show_infobar_ambient", showInfoBarAmbient);
@@ -400,7 +367,6 @@ public class MainActivity extends AppCompatActivity implements
 
             DataMap dataMap = new DataMap();
             dataMap.putLong("wear_timestamp", System.currentTimeMillis());
-            dataMap.putBoolean("use_24_hour_time", mUse24HourTime);
             dataMap.putBoolean("show_temperature", mShowTemperature);
             dataMap.putBoolean("use_celsius", mUseCelsius);
             dataMap.putBoolean("show_weather", mShowWeather);
@@ -416,11 +382,9 @@ public class MainActivity extends AppCompatActivity implements
     useDarkSkySwitch.setEnabled(advanced);
     darkSkyKeyEditText.setEnabled(advanced);
 
-    use24HourTimeSwitch.setChecked(use24HourTime);
     showTemperatureSwitch.setChecked(showTemperature);
     useCelsiusSwitch.setChecked(useCelsius);
     showWeatherSwitch.setChecked(showWeather);
-    useEuropeanDateFormatSwitch.setChecked(useEuropeanDateFormat);
     showTemperatureDecimalSwitch.setChecked(showTemperatureDecimalPoint);
     useThinAmbientSwitch.setChecked(useThinAmbient);
     showInfoBarAmbientSwitch.setChecked(showInfoBarAmbient);
@@ -434,7 +398,6 @@ public class MainActivity extends AppCompatActivity implements
     String TAG = "updateStatus";
     try {
       long timestamp = dataMap.getLong("wear_timestamp");
-      boolean mUse24HourTime = dataMap.getBoolean("use_24_hour_time");
       boolean mShowTemperature = dataMap.getBoolean("show_temperature");
       boolean mUseCelsius = dataMap.getBoolean("use_celsius");
       boolean mShowWeather = dataMap.getBoolean("show_weather");

--- a/phoneApp/src/main/res/layout/activity_main.xml
+++ b/phoneApp/src/main/res/layout/activity_main.xml
@@ -78,18 +78,6 @@
         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
       <Switch
-        android:id="@+id/dateFormatSwitch"
-        android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:text="@string/european_date_format"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/weatherSwitch" />
-
-      <Switch
         android:id="@+id/useThinAmbientSwitch"
         android:layout_width="match_parent"
         android:layout_height="48dp"
@@ -131,23 +119,8 @@
         android:text="@string/wearos_icon"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
-
-      <Switch
-        android:id="@+id/timeFormatSwitch"
-        android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:text="@string/universal_time"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-
-
-
     </LinearLayout>
+
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/phoneApp/src/main/res/values/strings.xml
+++ b/phoneApp/src/main/res/values/strings.xml
@@ -12,12 +12,10 @@
   <string name="purchase_purchased_thanks">Thanks for making further development of this watch face possible!</string>
   <string name="purchase_freebie">Request an unlock code</string>
   <string name="category_general">General</string>
-  <string name="european_date_format">Use European date format (Thu 14 Feb)</string>
   <string name="thin_text">Use thin text in ambient mode</string>
   <string name="infobar_ambient">Show date/weather in ambient mode</string>
   <string name="battery_level">Show battery level</string>
   <string name="wearos_icon">Show WearOS icon</string>
-  <string name="universal_time">Use 24 hour time</string>
   <string name="category_weather">Weather</string>
   <string name="temperature">Show the temperature</string>
   <string name="celsius">Use Celsius instead of Fahrenheit</string>

--- a/wearApp/src/main/java/com/corvettecole/pixelwatchface/models/Weather.java
+++ b/wearApp/src/main/java/com/corvettecole/pixelwatchface/models/Weather.java
@@ -9,6 +9,8 @@ import android.graphics.Bitmap;
 import com.corvettecole.pixelwatchface.R;
 import com.corvettecole.pixelwatchface.util.Constants;
 
+import java.text.DecimalFormatSymbols;
+
 public class Weather {
 
   private long mTime;
@@ -80,16 +82,12 @@ public class Weather {
   }
 
   @SuppressLint("DefaultLocale")
-  public String getFormattedTemperature(boolean useCelsius, boolean showTemperatureFractional,
-      boolean useEuropeanDateFormat) {
+  public String getFormattedTemperature(boolean useCelsius, boolean showTemperatureFractional) {
     String unit = useCelsius ? "°C" : "°F";
+    char decimalSep = DecimalFormatSymbols.getInstance().getDecimalSeparator();
     if (mTemperature == Double.MIN_VALUE) {
       if (showTemperatureFractional) {
-        if (useEuropeanDateFormat) {
-          return "--,-" + unit;
-        } else {
-          return "--.-" + unit;
-        }
+        return "--" + decimalSep + "-" + unit;
       } else {
         return "--" + unit;
       }

--- a/wearApp/src/main/java/com/corvettecole/pixelwatchface/util/Settings.java
+++ b/wearApp/src/main/java/com/corvettecole/pixelwatchface/util/Settings.java
@@ -12,8 +12,8 @@ public class Settings {
 
 
   private static volatile Settings instance;
-  private boolean use24HourTime, showTemperature, showWeatherIcon, useCelsius,
-      useEuropeanDateFormat, useThinAmbient, showInfoBarAmbient, showTemperatureFractional,
+  private boolean showTemperature, showWeatherIcon, useCelsius,
+      useThinAmbient, showInfoBarAmbient, showTemperatureFractional,
       showBattery, showWearIcon, useDarkSky, weatherChangeNotified, companionAppNotified, advanced;
   private String darkSkyAPIKey;
   private SharedPreferences sharedPreferences;
@@ -44,14 +44,6 @@ public class Settings {
     return instance;
   }
 
-  public boolean isUse24HourTime() {
-    return use24HourTime;
-  }
-
-  public void setUse24HourTime(boolean value) {
-    use24HourTime = value;
-  }
-
   public boolean isShowTemperature() {
     return showTemperature;
   }
@@ -66,14 +58,6 @@ public class Settings {
 
   public void setUseCelsius(boolean value) {
     useCelsius = value;
-  }
-
-  public boolean isUseEuropeanDateFormat() {
-    return useEuropeanDateFormat;
-  }
-
-  public void setUseEuropeanDateFormat(boolean value) {
-    useEuropeanDateFormat = value;
   }
 
   public boolean isUseThinAmbient() {
@@ -149,14 +133,12 @@ public class Settings {
     ArrayList<UpdatesRequired> updatesRequired = new ArrayList<>();
 
     Log.d(TAG, "timestamp: " + dataMap.getLong("timestamp"));
-    use24HourTime = dataMap.getBoolean("use_24_hour_time");
 
     showTemperature = dataMap.getBoolean("show_temperature", false);
     useCelsius = dataMap.getBoolean("use_celsius");
     showWeatherIcon = dataMap.getBoolean("show_weather", false);
     darkSkyAPIKey = dataMap.getString("dark_sky_api_key");
 
-    useEuropeanDateFormat = dataMap.getBoolean("use_european_date");
     showTemperatureFractional = dataMap.getBoolean("show_temperature_decimal");
 
     useThinAmbient = dataMap.getBoolean("use_thin_ambient");
@@ -183,7 +165,6 @@ public class Settings {
   }
 
   private void loadPreferences() {
-    use24HourTime = sharedPreferences.getBoolean("use_24_hour_time", false);
     showTemperature = sharedPreferences.getBoolean("show_temperature", false);
     showWeatherIcon = sharedPreferences.getBoolean("show_weather", false);
     useCelsius = sharedPreferences.getBoolean("use_celsius", true);
@@ -192,7 +173,6 @@ public class Settings {
     useThinAmbient = sharedPreferences.getBoolean("use_thin_ambient", false);
     showInfoBarAmbient = sharedPreferences.getBoolean("show_infobar_ambient", true);
 
-    useEuropeanDateFormat = sharedPreferences.getBoolean("use_european_date", false);
     showTemperatureFractional = sharedPreferences.getBoolean("show_temperature_decimal", false);
 
     darkSkyAPIKey = sharedPreferences.getString("dark_sky_api_key", "");
@@ -209,11 +189,9 @@ public class Settings {
 
   private void savePreferences() {
     SharedPreferences.Editor editor = sharedPreferences.edit();
-    editor.putBoolean("use_24_hour_time", use24HourTime);
     editor.putBoolean("show_temperature", showTemperature);
     editor.putBoolean("use_celsius", useCelsius);
     editor.putBoolean("show_weather", showWeatherIcon);
-    editor.putBoolean("use_european_date", useEuropeanDateFormat);
     editor.putBoolean("show_temperature_decimal", showTemperatureFractional);
     editor.putBoolean("use_thin_ambient", useThinAmbient);
     editor.putBoolean("show_infobar_ambient", showInfoBarAmbient);


### PR DESCRIPTION
This PR changes the way time and date gets formatted. It now uses the device's locale to generate the according localized strings. This also fixes some abbreviation mistakes for some languages (e.g. German). As a result, I removed the time and date formatting settings from the companion app as I think these settings should depend on the device's locale (can be discussed, however). The temperature decimal separator now also gets chosen according to the current locale instead of hardcoding it.