### PR TITLE
Gray text for infobar setting

### DIFF
--- a/phoneApp/src/main/java/com/corvettecole/pixelwatchface/MainActivity.java
+++ b/phoneApp/src/main/java/com/corvettecole/pixelwatchface/MainActivity.java
@@ -64,6 +64,7 @@ public class MainActivity extends AppCompatActivity implements
   private Switch useEuropeanDateFormatSwitch;
   private Switch showTemperatureDecimalSwitch;
   private Switch useThinAmbientSwitch;
+  private Switch useGrayInfoAmbientSwitch;
   private Switch showInfoBarAmbientSwitch;
   private Switch showBatterySwitch;
   private Switch showWearIconSwitch;
@@ -86,6 +87,7 @@ public class MainActivity extends AppCompatActivity implements
   private String darkSkyAPIKey;
   private boolean useDarkSky;
   private boolean useThinAmbient;
+  private boolean useGrayInfoAmbient;
   private boolean showInfoBarAmbient;
   private boolean showBattery;
   private boolean showWearIcon;
@@ -113,6 +115,7 @@ public class MainActivity extends AppCompatActivity implements
     useEuropeanDateFormatSwitch = findViewById(R.id.dateFormatSwitch);
     showTemperatureDecimalSwitch = findViewById(R.id.temperaturePrecisionSwitch);
     useThinAmbientSwitch = findViewById(R.id.useThinAmbientSwitch);
+    useGrayInfoAmbientSwitch = findViewById(R.id.useGrayInfoAmbientSwitch);
     showInfoBarAmbientSwitch = findViewById(R.id.infoBarAmbientSwitch);
     showBatterySwitch = findViewById(R.id.batterySwitch);
     showWearIconSwitch = findViewById(R.id.wearIconSwitch);
@@ -214,6 +217,15 @@ public class MainActivity extends AppCompatActivity implements
           @Override
           public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
             sharedPreferences.edit().putBoolean("show_infobar_ambient", isChecked).apply();
+            syncToWear();
+          }
+        });
+
+    useGrayInfoAmbientSwitch
+        .setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+          @Override
+          public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+            sharedPreferences.edit().putBoolean("use_gray_info_ambient", isChecked).apply();
             syncToWear();
           }
         });
@@ -334,7 +346,7 @@ public class MainActivity extends AppCompatActivity implements
     // if any of the settings are not their initial default values, or this isn't the first time the app was launched
     return showBattery && !use24HourTime && !showTemperature && useCelsius && !showWeather &&
         !useEuropeanDateFormat && !showTemperatureDecimalPoint && !useThinAmbient &&
-        showInfoBarAmbient && !showWearIcon && !advanced && firstLaunch;
+          useGrayInfoAmbient && showInfoBarAmbient && !showWearIcon && !advanced && firstLaunch;
   }
 
   private void loadPreferences() {
@@ -345,6 +357,7 @@ public class MainActivity extends AppCompatActivity implements
     useEuropeanDateFormat = sharedPreferences.getBoolean("use_european_date", false);
     showTemperatureDecimalPoint = sharedPreferences.getBoolean("show_temperature_decimal", false);
     useThinAmbient = sharedPreferences.getBoolean("use_thin_ambient", false);
+    useGrayInfoAmbient = sharedPreferences.getBoolean("use_gray_info_ambient", true);
     showInfoBarAmbient = sharedPreferences.getBoolean("show_infobar_ambient", true);
     showBattery = sharedPreferences.getBoolean("show_battery", true);
     showWearIcon = sharedPreferences.getBoolean("show_wear_icon", false);
@@ -381,6 +394,7 @@ public class MainActivity extends AppCompatActivity implements
     putDataMapReq.getDataMap().putBoolean("use_european_date", useEuropeanDateFormat);
     putDataMapReq.getDataMap().putBoolean("show_temperature_decimal", showTemperatureDecimalPoint);
     putDataMapReq.getDataMap().putBoolean("use_thin_ambient", useThinAmbient);
+    putDataMapReq.getDataMap().putBoolean("use_gray_info_ambient", useGrayInfoAmbient);
     putDataMapReq.getDataMap().putBoolean("show_infobar_ambient", showInfoBarAmbient);
     putDataMapReq.getDataMap().putString("dark_sky_api_key", darkSkyAPIKey);
     putDataMapReq.getDataMap().putBoolean("use_dark_sky", useDarkSky);
@@ -423,6 +437,7 @@ public class MainActivity extends AppCompatActivity implements
     useEuropeanDateFormatSwitch.setChecked(useEuropeanDateFormat);
     showTemperatureDecimalSwitch.setChecked(showTemperatureDecimalPoint);
     useThinAmbientSwitch.setChecked(useThinAmbient);
+    useGrayInfoAmbientSwitch.setChecked(useGrayInfoAmbient);
     showInfoBarAmbientSwitch.setChecked(showInfoBarAmbient);
     showBatterySwitch.setChecked(showBattery);
     showWearIconSwitch.setChecked(showWearIcon);

--- a/phoneApp/src/main/res/layout/activity_main.xml
+++ b/phoneApp/src/main/res/layout/activity_main.xml
@@ -101,6 +101,17 @@
         app:layout_constraintStart_toStartOf="parent" />
 
       <Switch
+          android:id="@+id/useGrayInfoAmbientSwitch"
+          android:layout_width="match_parent"
+          android:layout_height="48dp"
+          android:layout_marginTop="8dp"
+          android:layout_marginStart="8dp"
+          android:layout_marginEnd="8dp"
+          android:text="@string/infobar_gray_ambient"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent" />
+
+      <Switch
         android:id="@+id/infoBarAmbientSwitch"
         android:layout_width="match_parent"
         android:layout_height="48dp"

--- a/phoneApp/src/main/res/values/strings.xml
+++ b/phoneApp/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
   <string name="category_general">General</string>
   <string name="european_date_format">Use European date format (Thu 14 Feb)</string>
   <string name="thin_text">Use thin text in ambient mode</string>
+  <string name="infobar_gray_ambient">Use gray info text in ambient mode</string>
   <string name="infobar_ambient">Show date/weather in ambient mode</string>
   <string name="battery_level">Show battery level</string>
   <string name="wearos_icon">Show WearOS icon</string>

--- a/wearApp/src/main/java/com/corvettecole/pixelwatchface/ui/PixelWatchFace.java
+++ b/wearApp/src/main/java/com/corvettecole/pixelwatchface/ui/PixelWatchFace.java
@@ -495,7 +495,7 @@ public class PixelWatchFace extends CanvasWatchFaceService {
       return mSettings.isShowBattery() && !mSettings.isUse24HourTime() && !mSettings
           .isShowTemperature() && mSettings.isUseCelsius() && !mSettings.isShowWeatherIcon() &&
           !mSettings.isUseEuropeanDateFormat() && !mSettings.isShowTemperatureFractional()
-          && !mSettings.isUseThinAmbient() &&
+          && !mSettings.isUseThinAmbient() && mSettings.isUseGrayInfoAmbient() &&
           mSettings.isShowInfoBarAmbient() && !mSettings.isShowWearIcon() && !mSettings.isAdvanced()
           && (!mSettings.isCompanionAppNotified() && !mSettings.isWeatherChangeNotified());
     }
@@ -531,8 +531,11 @@ public class PixelWatchFace extends CanvasWatchFaceService {
           mTimePaint.setTypeface(mProductSans);
           mTimePaint.setStyle(Paint.Style.STROKE);
         }
-        mInfoPaint.setColor(
-            ContextCompat.getColor(getApplicationContext(), R.color.digital_text_ambient));
+        if (mSettings.isUseGrayInfoAmbient()) {
+          mInfoPaint.setColor(ContextCompat.getColor(getApplicationContext(), R.color.digital_text_ambient));
+        } else {
+          mInfoPaint.setColor(ContextCompat.getColor(getApplicationContext(), R.color.digital_text));
+        }
       } else {
         mTimePaint.setTypeface(mProductSans);
         mTimePaint.setStyle(Paint.Style.FILL);

--- a/wearApp/src/main/java/com/corvettecole/pixelwatchface/util/Settings.java
+++ b/wearApp/src/main/java/com/corvettecole/pixelwatchface/util/Settings.java
@@ -13,7 +13,7 @@ public class Settings {
 
   private static volatile Settings instance;
   private boolean use24HourTime, showTemperature, showWeatherIcon, useCelsius,
-      useEuropeanDateFormat, useThinAmbient, showInfoBarAmbient, showTemperatureFractional,
+      useEuropeanDateFormat, useThinAmbient, useGrayInfoAmbient, showInfoBarAmbient, showTemperatureFractional,
       showBattery, showWearIcon, useDarkSky, weatherChangeNotified, companionAppNotified, advanced;
   private String darkSkyAPIKey;
   private SharedPreferences sharedPreferences;
@@ -80,6 +80,8 @@ public class Settings {
     return useThinAmbient;
   }
 
+  public boolean isUseGrayInfoAmbient() { return useGrayInfoAmbient; }
+
   public boolean isShowInfoBarAmbient() {
     return showInfoBarAmbient;
   }
@@ -145,6 +147,7 @@ public class Settings {
     boolean tempUseDarkSky = useDarkSky;
 
     boolean tempUseThinAmbient = useThinAmbient;
+    boolean tempUseGrayInfoAmbient = useGrayInfoAmbient;
 
     ArrayList<UpdatesRequired> updatesRequired = new ArrayList<>();
 
@@ -160,6 +163,7 @@ public class Settings {
     showTemperatureFractional = dataMap.getBoolean("show_temperature_decimal");
 
     useThinAmbient = dataMap.getBoolean("use_thin_ambient");
+    useGrayInfoAmbient = dataMap.getBoolean("use_gray_info_ambient");
     showInfoBarAmbient = dataMap.getBoolean("show_infobar_ambient");
 
     showBattery = dataMap.getBoolean("show_battery", true);
@@ -174,7 +178,7 @@ public class Settings {
         != tempShowWeatherIcon) {  //detect if weather related settings has changed
       updatesRequired.add(UpdatesRequired.WEATHER);
     }
-    if (tempUseThinAmbient != useThinAmbient) { // check if font needs update
+    if (tempUseThinAmbient != useThinAmbient || tempUseGrayInfoAmbient != useGrayInfoAmbient) { // check if font needs update
       updatesRequired.add(UpdatesRequired.FONT);
     }
 
@@ -190,6 +194,7 @@ public class Settings {
 
 
     useThinAmbient = sharedPreferences.getBoolean("use_thin_ambient", false);
+    useGrayInfoAmbient = sharedPreferences.getBoolean("use_gray_info_ambient", true);
     showInfoBarAmbient = sharedPreferences.getBoolean("show_infobar_ambient", true);
 
     useEuropeanDateFormat = sharedPreferences.getBoolean("use_european_date", false);
@@ -216,6 +221,7 @@ public class Settings {
     editor.putBoolean("use_european_date", useEuropeanDateFormat);
     editor.putBoolean("show_temperature_decimal", showTemperatureFractional);
     editor.putBoolean("use_thin_ambient", useThinAmbient);
+    editor.putBoolean("use_gray_info_ambient", useGrayInfoAmbient);
     editor.putBoolean("show_infobar_ambient", showInfoBarAmbient);
     editor.putBoolean("show_battery", showBattery);
     editor.putBoolean("show_wear_icon", showWearIcon);


### PR DESCRIPTION
Closes #47 

Adds a setting to toggle gray text for the infobar when in ambient mode (defaults to true). If set to false, white text is used.