### PR TITLE
Add setting to toggle thin text for clock

### DIFF
--- a/phoneApp/src/main/java/com/corvettecole/pixelwatchface/MainActivity.java
+++ b/phoneApp/src/main/java/com/corvettecole/pixelwatchface/MainActivity.java
@@ -63,6 +63,7 @@ public class MainActivity extends AppCompatActivity implements
 
   private Switch useEuropeanDateFormatSwitch;
   private Switch showTemperatureDecimalSwitch;
+  private Switch useThinSwitch;
   private Switch useThinAmbientSwitch;
   private Switch showInfoBarAmbientSwitch;
   private Switch showBatterySwitch;
@@ -85,6 +86,7 @@ public class MainActivity extends AppCompatActivity implements
   private boolean showTemperatureDecimalPoint;
   private String darkSkyAPIKey;
   private boolean useDarkSky;
+  private boolean useThin;
   private boolean useThinAmbient;
   private boolean showInfoBarAmbient;
   private boolean showBattery;
@@ -112,6 +114,7 @@ public class MainActivity extends AppCompatActivity implements
 
     useEuropeanDateFormatSwitch = findViewById(R.id.dateFormatSwitch);
     showTemperatureDecimalSwitch = findViewById(R.id.temperaturePrecisionSwitch);
+    useThinSwitch = findViewById(R.id.useThinSwitch);
     useThinAmbientSwitch = findViewById(R.id.useThinAmbientSwitch);
     showInfoBarAmbientSwitch = findViewById(R.id.infoBarAmbientSwitch);
     showBatterySwitch = findViewById(R.id.batterySwitch);
@@ -200,6 +203,14 @@ public class MainActivity extends AppCompatActivity implements
             syncToWear();
           }
         });
+
+    useThinSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+        sharedPreferences.edit().putBoolean("use_thin", isChecked).apply();
+        syncToWear();
+      }
+    });
 
     useThinAmbientSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
       @Override
@@ -333,7 +344,7 @@ public class MainActivity extends AppCompatActivity implements
   private boolean shouldSuggestSettings() {
     // if any of the settings are not their initial default values, or this isn't the first time the app was launched
     return showBattery && !use24HourTime && !showTemperature && useCelsius && !showWeather &&
-        !useEuropeanDateFormat && !showTemperatureDecimalPoint && !useThinAmbient &&
+        !useEuropeanDateFormat && !showTemperatureDecimalPoint && !useThin && !useThinAmbient &&
         showInfoBarAmbient && !showWearIcon && !advanced && firstLaunch;
   }
 
@@ -344,6 +355,7 @@ public class MainActivity extends AppCompatActivity implements
     showWeather = sharedPreferences.getBoolean("show_weather", false);
     useEuropeanDateFormat = sharedPreferences.getBoolean("use_european_date", false);
     showTemperatureDecimalPoint = sharedPreferences.getBoolean("show_temperature_decimal", false);
+    useThin = sharedPreferences.getBoolean("use_thin", false);
     useThinAmbient = sharedPreferences.getBoolean("use_thin_ambient", false);
     showInfoBarAmbient = sharedPreferences.getBoolean("show_infobar_ambient", true);
     showBattery = sharedPreferences.getBoolean("show_battery", true);
@@ -380,6 +392,7 @@ public class MainActivity extends AppCompatActivity implements
     putDataMapReq.getDataMap().putBoolean("show_weather", showWeather);
     putDataMapReq.getDataMap().putBoolean("use_european_date", useEuropeanDateFormat);
     putDataMapReq.getDataMap().putBoolean("show_temperature_decimal", showTemperatureDecimalPoint);
+    putDataMapReq.getDataMap().putBoolean("use_thin", useThin);
     putDataMapReq.getDataMap().putBoolean("use_thin_ambient", useThinAmbient);
     putDataMapReq.getDataMap().putBoolean("show_infobar_ambient", showInfoBarAmbient);
     putDataMapReq.getDataMap().putString("dark_sky_api_key", darkSkyAPIKey);
@@ -422,6 +435,7 @@ public class MainActivity extends AppCompatActivity implements
     showWeatherSwitch.setChecked(showWeather);
     useEuropeanDateFormatSwitch.setChecked(useEuropeanDateFormat);
     showTemperatureDecimalSwitch.setChecked(showTemperatureDecimalPoint);
+    useThinSwitch.setChecked(useThin);
     useThinAmbientSwitch.setChecked(useThinAmbient);
     showInfoBarAmbientSwitch.setChecked(showInfoBarAmbient);
     showBatterySwitch.setChecked(showBattery);

--- a/phoneApp/src/main/res/layout/activity_main.xml
+++ b/phoneApp/src/main/res/layout/activity_main.xml
@@ -90,13 +90,24 @@
         app:layout_constraintTop_toBottomOf="@+id/weatherSwitch" />
 
       <Switch
-        android:id="@+id/useThinAmbientSwitch"
+        android:id="@+id/useThinSwitch"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:layout_marginTop="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:text="@string/thin_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+      <Switch
+        android:id="@+id/useThinAmbientSwitch"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/thin_ambient_text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 

--- a/phoneApp/src/main/res/values/strings.xml
+++ b/phoneApp/src/main/res/values/strings.xml
@@ -13,7 +13,8 @@
   <string name="purchase_freebie">Request an unlock code</string>
   <string name="category_general">General</string>
   <string name="european_date_format">Use European date format (Thu 14 Feb)</string>
-  <string name="thin_text">Use thin text in ambient mode</string>
+  <string name="thin_text">Use thin text for clock</string>
+  <string name="thin_ambient_text">Use thin text for clock in ambient mode</string>
   <string name="infobar_ambient">Show date/weather in ambient mode</string>
   <string name="battery_level">Show battery level</string>
   <string name="wearos_icon">Show WearOS icon</string>

--- a/wearApp/src/main/java/com/corvettecole/pixelwatchface/ui/PixelWatchFace.java
+++ b/wearApp/src/main/java/com/corvettecole/pixelwatchface/ui/PixelWatchFace.java
@@ -495,7 +495,7 @@ public class PixelWatchFace extends CanvasWatchFaceService {
       return mSettings.isShowBattery() && !mSettings.isUse24HourTime() && !mSettings
           .isShowTemperature() && mSettings.isUseCelsius() && !mSettings.isShowWeatherIcon() &&
           !mSettings.isUseEuropeanDateFormat() && !mSettings.isShowTemperatureFractional()
-          && !mSettings.isUseThinAmbient() &&
+          && !mSettings.isUseThin() && !mSettings.isUseThinAmbient() &&
           mSettings.isShowInfoBarAmbient() && !mSettings.isShowWearIcon() && !mSettings.isAdvanced()
           && (!mSettings.isCompanionAppNotified() && !mSettings.isWeatherChangeNotified());
     }
@@ -534,8 +534,13 @@ public class PixelWatchFace extends CanvasWatchFaceService {
         mInfoPaint.setColor(
             ContextCompat.getColor(getApplicationContext(), R.color.digital_text_ambient));
       } else {
-        mTimePaint.setTypeface(mProductSans);
-        mTimePaint.setStyle(Paint.Style.FILL);
+        if (mSettings.isUseThin()) {
+          mTimePaint.setStyle(Paint.Style.FILL);
+          mTimePaint.setTypeface(mProductSansThin);
+        } else {
+          mTimePaint.setTypeface(mProductSans);
+          mTimePaint.setStyle(Paint.Style.FILL);
+        }
         mInfoPaint.setColor(ContextCompat.getColor(getApplicationContext(), R.color.digital_text));
       }
     }

--- a/wearApp/src/main/java/com/corvettecole/pixelwatchface/util/Settings.java
+++ b/wearApp/src/main/java/com/corvettecole/pixelwatchface/util/Settings.java
@@ -13,7 +13,7 @@ public class Settings {
 
   private static volatile Settings instance;
   private boolean use24HourTime, showTemperature, showWeatherIcon, useCelsius,
-      useEuropeanDateFormat, useThinAmbient, showInfoBarAmbient, showTemperatureFractional,
+      useEuropeanDateFormat, useThin, useThinAmbient, showInfoBarAmbient, showTemperatureFractional,
       showBattery, showWearIcon, useDarkSky, weatherChangeNotified, companionAppNotified, advanced;
   private String darkSkyAPIKey;
   private SharedPreferences sharedPreferences;
@@ -76,9 +76,11 @@ public class Settings {
     useEuropeanDateFormat = value;
   }
 
-  public boolean isUseThinAmbient() {
-    return useThinAmbient;
+  public boolean isUseThin() {
+    return useThin;
   }
+
+  public boolean isUseThinAmbient() { return useThinAmbient; }
 
   public boolean isShowInfoBarAmbient() {
     return showInfoBarAmbient;
@@ -144,6 +146,7 @@ public class Settings {
     boolean tempShowWeatherIcon = showWeatherIcon;
     boolean tempUseDarkSky = useDarkSky;
 
+    boolean tempUseThin = useThin;
     boolean tempUseThinAmbient = useThinAmbient;
 
     ArrayList<UpdatesRequired> updatesRequired = new ArrayList<>();
@@ -159,6 +162,7 @@ public class Settings {
     useEuropeanDateFormat = dataMap.getBoolean("use_european_date");
     showTemperatureFractional = dataMap.getBoolean("show_temperature_decimal");
 
+    useThin = dataMap.getBoolean("use_thin");
     useThinAmbient = dataMap.getBoolean("use_thin_ambient");
     showInfoBarAmbient = dataMap.getBoolean("show_infobar_ambient");
 
@@ -174,7 +178,7 @@ public class Settings {
         != tempShowWeatherIcon) {  //detect if weather related settings has changed
       updatesRequired.add(UpdatesRequired.WEATHER);
     }
-    if (tempUseThinAmbient != useThinAmbient) { // check if font needs update
+    if (tempUseThin != useThin || tempUseThinAmbient != useThinAmbient) { // check if font needs update
       updatesRequired.add(UpdatesRequired.FONT);
     }
 
@@ -188,7 +192,7 @@ public class Settings {
     showWeatherIcon = sharedPreferences.getBoolean("show_weather", false);
     useCelsius = sharedPreferences.getBoolean("use_celsius", true);
 
-
+    useThin = sharedPreferences.getBoolean("use_thin", false);
     useThinAmbient = sharedPreferences.getBoolean("use_thin_ambient", false);
     showInfoBarAmbient = sharedPreferences.getBoolean("show_infobar_ambient", true);
 
@@ -215,6 +219,7 @@ public class Settings {
     editor.putBoolean("show_weather", showWeatherIcon);
     editor.putBoolean("use_european_date", useEuropeanDateFormat);
     editor.putBoolean("show_temperature_decimal", showTemperatureFractional);
+    editor.putBoolean("use_thin", useThin);
     editor.putBoolean("use_thin_ambient", useThinAmbient);
     editor.putBoolean("show_infobar_ambient", showInfoBarAmbient);
     editor.putBoolean("show_battery", showBattery);


### PR DESCRIPTION
Closes #40 

Adds setting to toggle between thin and normal text for clock (similar to ambient mode).